### PR TITLE
Crash in emitapplyexpr

### DIFF
--- a/crashes/23172-lowering-silgenfunction-emitapplyexpr.swift
+++ b/crashes/23172-lowering-silgenfunction-emitapplyexpr.swift
@@ -1,0 +1,11 @@
+func f() {
+	var n = 0
+	class A {
+		func g() {
+			n = 1			// This kills the swiftc
+		}
+	}
+	
+	let a = A()
+	a.g()
+}


### PR DESCRIPTION
Added human-detected crash when accessing function-level var from a method on an inner class.