### PR TITLE
Added a new human-detected bug

### DIFF
--- a/crashes/23408-missing-type-in-generic-constraint.swift
+++ b/crashes/23408-missing-type-in-generic-constraint.swift
@@ -1,0 +1,10 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/zneak (zneak)
+
+protocol A {
+	typealias T
+}
+
+class B<T, U: A where A.T == notfound> {
+	var t: T
+}

--- a/crashes/23409-circular-typealias.swift
+++ b/crashes/23409-circular-typealias.swift
@@ -1,0 +1,10 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/zneak (zneak)
+
+protocol A {
+	typealias BB: B
+}
+
+protocol B {
+	typealias AA: A
+}


### PR DESCRIPTION
It appears similar to 21270 (it uses a missing type in a generic constraint clause), but the stack trace is different (21270 crashes at lexing, this one crashes at validation).