### PR TITLE
23892: Fixpoint Combinator for Types

### DIFF
--- a/crashes/23892-swift-archetypebuilder-resolvearchetype.swift
+++ b/crashes/23892-swift-archetypebuilder-resolvearchetype.swift
@@ -1,0 +1,7 @@
+public protocol Functor {
+	typealias A
+}
+
+class Mu<F : Functor where F.A == Mu<F>> {
+	let mu : F
+}


### PR DESCRIPTION
The definition of the Mu type causes a crash in the `swift::ArchetypeBuilder::resolveArchetype`. This one makes the mad scientist in me quite sad.