### PR TITLE
Added crash - 23893 - IRGen emitObjCExistentialDowncast

### DIFF
--- a/crashes/23893-swift-irgen-emitObjCExistentialDowncast.swift
+++ b/crashes/23893-swift-irgen-emitObjCExistentialDowncast.swift
@@ -1,0 +1,6 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+
+import Foundation
+
+UnsafePointer<CFDictionary?>().memory as NSDictionary


### PR DESCRIPTION
Hey @practicalswift, got a new one for ya (or so I think :))! 

`CFDictionary` must be optional for the crash to occur.