### PR TITLE
Added crash - 23909 - IRGen emitScalarExistentialDowncast

### DIFF
--- a/crashes/23909-swift-irgen-emitscalarexistentialdowncast.swift
+++ b/crashes/23909-swift-irgen-emitscalarexistentialdowncast.swift
@@ -1,0 +1,5 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+
+import Foundation
+UnsafePointer<CFDictionary?>().memory as! NSDictionary


### PR DESCRIPTION
This is identical to [23893](https://github.com/practicalswift/swift-compiler-crashes/pull/51) (which was just fixed in Xcode 6.3 Beta 1), except it uses the newly added forced downcast.