### PR TITLE
Added crash - 23910 - No stack trace

### DIFF
--- a/crashes/23910-no-stacktrace.swift
+++ b/crashes/23910-no-stacktrace.swift
@@ -1,0 +1,5 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+// Discovered in https://github.com/kareman/SwiftShell (see issue #8)
+
+var a: Int { get { return 1 } }


### PR DESCRIPTION
- This was discovered in [SwiftShell](https://github.com/kareman/SwiftShell)
- See issue https://github.com/kareman/SwiftShell/issues/8
- This was working previously (Xcode 6.1.1) so looks to be a compiler regression
- The property type doesn’t seem to matter
- The stack trace contains nothing distinct in it, so I can’t tell if its unique