### PR TITLE
Add crash 24607-swift-irgen-unpackenumpayload-claim

### DIFF
--- a/crashes/24607-swift-irgen-unpackenumpayload-claim.swift
+++ b/crashes/24607-swift-irgen-unpackenumpayload-claim.swift
@@ -1,0 +1,18 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/adamschlag (adamschlag)
+// rdar://20060127
+
+struct A {
+    var b: B? = B()
+}
+
+struct B {
+    let c: C = C()
+    let d: D? = D()
+}
+
+struct C {
+    let str = ""
+}
+
+struct D {}


### PR DESCRIPTION
- Discovered in Xcode 6.3b2, still crashes in 6.3b3