### PR TITLE
New Swift compiler crash with extension of generic type with type alias

### DIFF
--- a/crashes/24882-extension-generictype-typealias.swift
+++ b/crashes/24882-extension-generictype-typealias.swift
@@ -1,0 +1,29 @@
+import Foundation;
+
+public protocol HasReflect {
+    typealias T : HasReflect
+    static func reflect() -> Type<T>
+}
+public protocol JsonSerializable : HasReflect, StringSerializable {
+}
+public protocol StringSerializable {
+    typealias T
+    static func fromString(string:String) -> T?
+}
+public class TypeAccessor {}
+
+public class Type<T : HasReflect> : TypeAccessor {
+}
+
+public class QueryResponse<T : JsonSerializable> {}
+
+extension QueryResponse : JsonSerializable
+{
+    public static func reflect() -> Type<QueryResponse<T>> {
+        return Type<QueryResponse<T>>()
+    }
+    public static func fromString(string:String) -> QueryResponse<T>? {
+        return nil
+    }
+}
+


### PR DESCRIPTION
First time submitting a compiler crash, just using the last crash number + 1. 
Please let me know if there's anything else I need to do.