### PR TITLE
Added crash (regression) - 24888 - emitClosureValue

### DIFF
--- a/crashes/24888-swift-lowering-silgenfunction-emitClosureValue.swift
+++ b/crashes/24888-swift-lowering-silgenfunction-emitClosureValue.swift
@@ -1,0 +1,8 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+
+func a() {
+    func b<T>(c: UnsafePointer<T>) { }
+    var d = 0
+    withUnsafePointer(&d, b)
+}


### PR DESCRIPTION
Crashes in **Xcode 7 Beta 1**, was working in **Xcode 6.3.2**.

The compiler doesn’t seem to like having an inner function taking a generic arg.