### PR TITLE
Add timeout cases 24889 & 24890 - "Expression was too complex..."

### DIFF
--- a/crashes/24889-too-complex-to-be-solved-in-reasonable-time.timeout.swift
+++ b/crashes/24889-too-complex-to-be-solved-in-reasonable-time.timeout.swift
@@ -1,0 +1,9 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+//
+// This compiles in Xcode 6.3.2, but quite slowly. It no longer does in Xcode 7
+// Beta 1, throwing the "Expression was too complex to be solved in reasonable
+// time" error.
+
+let a = [0, 1, 2]
+a.filter { $0 == 0 || $0 == 1 || $0 == 2 }

--- a/crashes/24890-too-complex-to-be-solved-in-reasonable-time.timeout.swift
+++ b/crashes/24890-too-complex-to-be-solved-in-reasonable-time.timeout.swift
@@ -1,0 +1,8 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+//
+// Similar to 23903, however, this was working in Xcode 6.3.2, no longer in
+// Xcode 7 Beta 1, while 23903 was not.
+
+let a = [CChar](count: 4, repeatedValue: 0)
+let b = UInt32(a[0]) << 24 + UInt32(a[1]) << 16 + UInt32(a[2]) << 8  + UInt32(a[3])


### PR DESCRIPTION
**24889**
Compiles in Xcode 6.3.2, but quite slowly. It no longer does in Xcode 7 Beta 1, throwing the _"Expression was too complex to be solved in reasonable time"_ error.

**24890**
Similar to 23903 (another _"Expression was too complex.."_ error), however, this was working in Xcode 6.3.2, no longer in Xcode 7 Beta 1, while 23903 was not.

Crash numbering here assumes #74 is getting merged. If it doesn't, I can update this PR accordingly.