### PR TITLE
Added runtime crash (regression) - 24891 - using utsname struct

### DIFF
--- a/crashes/24891-using-utsname-struct.runtime.swift
+++ b/crashes/24891-using-utsname-struct.runtime.swift
@@ -1,0 +1,7 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/beltex (beltex)
+//
+// Crashes at runtime. Regression in Xcode 7 Beta 1.
+
+import Darwin
+print(utsname())


### PR DESCRIPTION
Crashes at runtime. Regression in **Xcode 7 Beta 1**. Anything besides simply initing the struct seems to cause a crash.

Crash numbering here assumes #74 & #75 are getting merged. If they don't, I can update this PR accordingly.