### PR TITLE
Segmentation fault: 11 enum with indirect & func

### DIFF
--- a/crashes/26808-enum-with-indirect-and-function.swift
+++ b/crashes/26808-enum-with-indirect-and-function.swift
@@ -1,0 +1,7 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by Andrew Bennett http:/github.com/therealbnut (@therealbnut)
+
+enum E {
+    indirect case C(E)
+    func f(){}
+}


### PR DESCRIPTION
Outputs
 > Command failed due to signal: Segmentation fault: 11

In XCode 7.0 beta 5 (7A176x)
