### PR TITLE
Adding crash related to generic enums with tuple payloads

### DIFF
--- a/crashes/26813-generic-enum-tuple-optional-payload.swift
+++ b/crashes/26813-generic-enum-tuple-optional-payload.swift
@@ -1,0 +1,11 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/austinzheng (Austin Zheng)
+
+enum A<T> {
+  case Just(T)
+  case Error
+}
+
+func foo() -> A<(String, String?)> {
+  return A.Just("abc", "def")
+}

--- a/crashes/26813-generic-enum-tuple-optional-payload.swift
+++ b/crashes/26813-generic-enum-tuple-optional-payload.swift
@@ -1,6 +1,8 @@
 // Distributed under the terms of the MIT license
 // Test case submitted to project by https://github.com/austinzheng (Austin Zheng)
 
+import Foundation
+
 enum A<T> {
   case Just(T)
   case Error


### PR DESCRIPTION
This crash occurs as of Xcode 7.0 beta 6 (7A192o). If the second argument in the return value is changed to `nil` the function compiles properly. 