### PR TITLE
Add crash for struct extension with init in another file

### DIFF
--- a/crashes/27817-anonymous-namespace-rvalueemitter-emitstringliteral.part1.swift
+++ b/crashes/27817-anonymous-namespace-rvalueemitter-emitstringliteral.part1.swift
@@ -1,0 +1,6 @@
+// Distributed under the terms of the MIT license
+// Test case found by https://github.com/benshan (Ben Shanfelder)
+
+struct Test {
+    let a: String = ""
+}

--- a/crashes/27817-anonymous-namespace-rvalueemitter-emitstringliteral.part2.swift
+++ b/crashes/27817-anonymous-namespace-rvalueemitter-emitstringliteral.part2.swift
@@ -1,0 +1,8 @@
+// Distributed under the terms of the MIT license
+// Test case found by https://github.com/benshan (Ben Shanfelder)
+
+extension Test {
+    init?(x: Float) {
+        return nil
+    }
+}


### PR DESCRIPTION
Found in xcode7.0.1 and xcode7.1b2