### PR TITLE
Add crash for defer in init of subclass

### DIFF
--- a/crashes/27817-swift-astvisitor.swift
+++ b/crashes/27817-swift-astvisitor.swift
@@ -1,0 +1,16 @@
+// Distributed under the terms of the MIT license
+// Test case submitted to project by https://github.com/zats (Sash Zats)
+// Radar: http://openradar.appspot.com/22917580
+
+class B {
+    init() {
+    }
+}
+
+class A: B {
+    override init() {
+        defer {
+            super.init()
+        }
+    }
+}


### PR DESCRIPTION
I ran into while tried to use `defer` as a workaround for the failable initialisers requiring calling `super.init` before returning `nil`