### PR TITLE
added RawRepresentable extension crash

### DIFF
--- a/crashes/28071-rawrepresentable-extension-with-initializer.swift
+++ b/crashes/28071-rawrepresentable-extension-with-initializer.swift
@@ -1,0 +1,14 @@
+
+extension RawRepresentable {
+    
+    init?(rawValue optionalRawValue: RawValue?) {
+        guard let rawValue = optionalRawValue, value = Self(rawValue: rawValue) else { return nil }
+        self = value
+    }
+}
+
+enum E: Int {
+    case A = 0, B
+}
+
+let v: E = .A


### PR DESCRIPTION
```
$ swift 28071-rawrepresentable-extension-with-initializer.swift
Segmentation fault: 11
```

```
$ xcrun swiftc 28071-rawrepresentable-extension-with-initializer.swift 2>&1 | egrep 'swift.*0x'  | egrep -v '(PrintStackTrace|SignalHandler)' | head -1
```
(produces no output)