### PR TITLE
Add crash for missing getter in extension property.

### DIFF
--- a/crashes/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
+++ b/crashes/28184-swift-constraints-constraintsystem-gettypeofmemberreference.swift
@@ -1,0 +1,11 @@
+// Distributed under the terms of the MIT license
+// Test case found by https://github.com/benshan (Ben Shanfelder)
+
+import Foundation
+
+extension NSObject {
+    var handler: Int {
+        // FIXME: Crashing due to lack of get {}
+        set {}
+    }
+}


### PR DESCRIPTION
Found in xcode7.1.1 and xcode7.2b4.