### PR TITLE
Add crash for type mismatch between protocol function and extension

### DIFF
--- a/crashes/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
+++ b/crashes/28186-swift-silwitnessvisitor-visitprotocoldecl.swift
@@ -1,0 +1,21 @@
+
+import Foundation
+
+protocol P {
+	static func f() -> Self
+		static func g() -> Self
+}
+
+extension P {
+	static func f() -> P {
+		return g()
+	}
+}
+
+extension NSData: P {
+	static func g() -> Self {
+		return self.init()
+	}
+}
+
+


### PR DESCRIPTION
This code probably should not compile (there is a type mismatch between the return types on lines 5 and 10), however it crashes the compiler instead of displaying an error. Replacing `Self` with `P` on line 5 results in successful compilation; doing the opposite on line 10 results in a compile error.

    % xcrun swiftc crash.swift 2>&1 | egrep 'swift.*0x' | egrep -v '(PrintStackTrace|SignalHandler)' | head -1
    4  swift                    0x0000000109aa6707 swift::SILWitnessVisitor<(anonymous namespace)::SILGenConformance>::visitProtocolDecl(swift::ProtocolDecl*) + 999

    % xcrun swiftc --version
    Apple Swift version 2.1.1 (swiftlang-700.1.101.15 clang-700.1.81)
    Target: x86_64-apple-darwin15.2.0