### PR TITLE
Add crash for weak object referenced object method with missing argument.

### DIFF
--- a/crashes/28187-llvm-foldingset-swift-constraints-constraintlocator.swift
+++ b/crashes/28187-llvm-foldingset-swift-constraints-constraintlocator.swift
@@ -1,0 +1,20 @@
+//
+//  Created by Alvar Hansen on 18/12/15.
+//
+
+class Foo {
+    
+    func callA() {
+        Foo().methodWithBlock { [weak self] (session) -> Void in
+            //second argument missing
+            self?.callB(session)
+        }
+    }
+    
+    func methodWithBlock(call: ((AnyObject)->Void)) {
+    }
+    
+    func callB(param1: AnyObject, param2: AnyObject) {
+    }
+    
+}


### PR DESCRIPTION
This code should not compile, but instead of giving error it gives segmentation fault 11.