### PR TITLE
Attempt to enumerate Mirror children using forEach with function reference crashes compiler

### DIFF
--- a/crashes/28721-irgensilfunction-visitfullapplysite.swift
+++ b/crashes/28721-irgensilfunction-visitfullapplysite.swift
@@ -1,0 +1,8 @@
+
+func f(value: Any) {
+}
+
+struct A {
+}
+
+Mirror(reflecting: A()).children.forEach(f)

--- a/crashes/28721-irgensilfunction-visitfullapplysite.swift
+++ b/crashes/28721-irgensilfunction-visitfullapplysite.swift
@@ -1,3 +1,5 @@
+// Distributed under the terms of the MIT license
+// Submitted by https://github.com/deville (Andrii Chernenko)
 
 func f(value: Any) {
 }


### PR DESCRIPTION
Tested against Swift version 2.1.1:

```
$ ./test.sh crashes/28721-irgensilfunction-visitfullapplysite.swift

Running tests against: Apple Swift version 2.1.1 (swiftlang-700.1.101.15 clang-700.1.81)
Usage: ./test.sh [-v] [-q] [-c<columns>] [-l] [file ...]
Adding a new test case? The crash id to use for the next test case is 28722.
  ✘  28721 irgensilfunction visitfullapplysite                                                                                                                                                                                                                                                             (87f7985f52)

** Results: 1 of 1 tests crashed the compiler **
```

Problem is also reproduced for similar functions like `map`, `flatMap`.

Normal collections (for example, arrays) are not affected.

Enumeration using in-place closure works as expected: 
```
Mirror(reflecting: A()).children.forEach({
  f($0)
})
```