### PR TITLE
Calling default implementation as a curried method causes a crash

### DIFF
--- a/crashes/28654-swift-lowering-silgenfunction-emitopenexistential.swift
+++ b/crashes/28654-swift-lowering-silgenfunction-emitopenexistential.swift
@@ -1,0 +1,13 @@
+protocol P {}
+
+extension P {
+    func defaultImplementation() {}
+}
+
+class C : P {
+    
+    func customImplementation() {
+        P.defaultImplementation(self)()
+    }
+}
+


### PR DESCRIPTION
Tested against swift-DEVELOPMENT-SNAPSHOT-2017-01-17-a.

I've also filed a [bug](https://bugs.swift.org/browse/SR-3670).