### PR TITLE
Using nested typealias from a generic struct causes a crash

### DIFF
--- a/crashes-fuzzing/28247-nominaltypedecl-hasfixedlayout.swift
+++ b/crashes-fuzzing/28247-nominaltypedecl-hasfixedlayout.swift
@@ -1,0 +1,7 @@
+public struct T<Specific> {
+    public typealias Closure = (Specific) -> Void
+}
+
+let closure: T.Closure = { (input: String) in
+    print("\(input)")
+}


### PR DESCRIPTION
Tested against Swift 3.1 release (GM Xcode 8.3) and filed [here](https://bugs.swift.org/browse/SR-4390).