### PR TITLE
Add crash (recursive generic function call with `[Any]?` argument)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Contributor hall of fame
 | <a href="https://github.com/AlexDenisov">@AlexDenisov</a> – Alexey Denisov | <a href="https://twitter.com/1101_debian">@1101_debian</a> | 1 case | Xcode6.0-Beta6 |
 | <a href="https://github.com/ArtisOracle">@ArtisOracle</a> – Stefan Arambasich | <a href="https://twitter.com/ArtisOracle">@ArtisOracle</a> | 1 case | Xcode6.1.1-GM-Seed |
 | <a href="https://github.com/champo">@champo</a> – Juan Pablo Civile | <a href="https://twitter.com/elchampo">@elchampo</a> | 1 case | Xcode6.3-Beta2 |
+| <a href="https://github.com/dusek">@dusek</a> – Boris Dušek | <a href="https://twitter.com/BorisDusek">@BorisDusek</a> | 1 case | Xcode 8.3.1 |
 | <a href="https://github.com/hendriks73">@hendriks73</a> – Hendrik Schreiber| <a href="https://twitter.com/h_schreiber">@h_schreiber</a> | 1 case | Xcode6.2-Beta4 |
 | <a href="https://github.com/invalidname">@invalidname</a> – Chris Adamson | <a href="https://twitter.com/invalidname">@invalidname</a> | 1 case | Xcode6.2-Beta4 |
 | <a href="https://github.com/jansabbe">@jansabbe</a> – Jan Sabbe | <a href="https://twitter.com/jansabbe">@jansabbe</a> | 1 case | Xcode6.0-Beta6 |

--- a/crashes/28736-anonymous-namespacesilverifier-require.swift
+++ b/crashes/28736-anonymous-namespacesilverifier-require.swift
@@ -1,0 +1,11 @@
+// This source file is part of the Swift.org open source project
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// RUN: not --crash %target-swift-frontend %s -emit-ir -O
+
+func f<T>(_ a: T) -> Void {
+    f(nil as [Any]?)
+}


### PR DESCRIPTION
Tested on current swift master [be985b1ec701e12c9c02cd1a7933759a15b68a71](https://github.com/apple/swift/commit/be985b1ec701e12c9c02cd1a7933759a15b68a71)

Originally found (with different stack trace) on Swift 3.1 in github.com/giginet/JSONMatcher project during `pod lib lint`, then reduced and reported as [SR-4549](https://bugs.swift.org/browse/SR-4549). Then further reduced with Swift master to this very minimal repro of a compiler crash. I just verified this latest repro crashes on Swift 3.1 as well (with different stack trace).